### PR TITLE
Merge instead of overwrite multiple virtualtext

### DIFF
--- a/spec/base.lua
+++ b/spec/base.lua
@@ -15,7 +15,7 @@ function test_base.test_print_with_split()
   local expected_virtual_text = '{ "wow", "wow" }'
   local virtual_txt = vim.trim(t.get_virtual_text(0)[1][1])
 
-  t.assert_str_contains(expected_virtual_text, virtual_txt)
+  t.assert_str_contains(virtual_txt, expected_virtual_text)
 end
 
 function test_base.test_function_print()
@@ -44,4 +44,26 @@ function test_base.test_error_msg()
 
   t.assert_equals(t.nvim('get_var', 'luapad_status'), 'error')
   t.assert_equals(virtual_txt[2], "ErrorMsg")
+end
+
+function test_base.test_print_in_loops()
+  t.set_lines(0,0, [[for i=0, 5 do
+    print(i)
+    end]])
+
+  local expected_virtual_text = '0 | 1 | 2 | 3 | 4 | 5'
+  local virtual_txt = vim.trim(t.get_virtual_text(1)[1][1])
+
+  t.assert_str_contains(virtual_txt, expected_virtual_text)
+end
+
+function test_base.test_print_from_multiple_called_methods()
+  t.set_lines(0,0, [[function asdf(a) print(a) end
+    asdf('foo')
+    asdf('bar')]])
+
+  local expected_virtual_text = '"foo" | "bar"'
+  local virtual_txt = vim.trim(t.get_virtual_text(0)[1][1])
+
+  t.assert_str_contains(virtual_txt, expected_virtual_text)
 end

--- a/spec/test_helper.lua
+++ b/spec/test_helper.lua
@@ -95,7 +95,7 @@ function TestHelper.new_group()
     setUp = function()
       TestHelper.setup()
       TestHelper.command('Luapad')
-      TestHelper.command('only')
+      -- TestHelper.command('only')
     end,
     tearDown = function()
       TestHelper.finish()


### PR DESCRIPTION
Now, print function called multiple times, will show entire output, instead of just the last call.

```lua
for i = 1, 5 do
  print(i) -- 1 | 2 | 3 | 4 | 5
end

function hello(str)
  print(str) -- "foo" | "bar"
end

hello('foo')
hello('bar')
```

close #1 