### PR TITLE
Fix temp dir

### DIFF
--- a/lua/luapad/tools.lua
+++ b/lua/luapad/tools.lua
@@ -13,9 +13,7 @@ end
 local sep = vim.api.nvim_call_function('has', {'win32'}) == 0 and '/' or '\\'
 
 local function path(...)
-  local str = debug.getinfo(2, "S").source:sub(2)
-  root = str:match(("(.*)lua%sluapad.lua"):format(sep))
-  return root .. table.concat({...}, (sep))
+  return vim.api.nvim_eval('tempname()')
 end
 
 local function create_file(f)


### PR DESCRIPTION
On my installation of this plugin I have no write access to the installation directory, but the current implementation expect write access.

My workaround is to use the vim function tempname().