### PR TITLE
Add a setting to configure the split orientation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ With vim-plug:
 
 Luapadd provides three different commands, that will help you with developing neovim plugins in lua:
   - **Luapad** - which open interactive scratch buffer with real time evaluation.
-  - **LuaRun** - which run content of current buffer as lua script in new scope. You do not need to write file to disc or have to worry about overwriting functions in global scope. 
+  - **LuaRun** - which run content of current buffer as lua script in new scope. You do not need to write file to disc or have to worry about overwriting functions in global scope.
   - ~~**Lua** - which is extension of native lua command with function completion.~~ *This command will be removed in the next release, because the current version of Neovim has built-in cmd completion.*
 
 From version 0.2 luapad will move towards lua api exposure. Several useful functions are already available.
@@ -105,6 +105,7 @@ You can configure luapad via `require('luapad').setup({})` function (or its alia
 | error_highlight         | 'ErrorMsg'        | Highlight group used to coloring luapad error indicator                                                                                                                                                 |
 | on_init                 | function          | Callback function called after creating new luapad instance                                                                                                                                                                                                          |
 | context                 | {}                | The default context tbl in which luapad buffer is evaluated. Its properties will be available in buffer as "global" variables.
+| split_orientation       | 'vertical'        | The orientation of the split created by `Luapad`.                  |
 
 
 

--- a/lua/luapad.lua
+++ b/lua/luapad.lua
@@ -1,4 +1,5 @@
 local set_config = require'luapad.config'.set_config
+local config = require'luapad.config'.config
 local vim_config_disabled_warn = require'luapad.config'.vim_config_disabled_warn
 
 local Evaluator = require'luapad.evaluator'
@@ -18,7 +19,12 @@ local function init()
   -- hacky solution to deal with native lsp
   remove_file(file_path)
   create_file(file_path)
-  vim.api.nvim_command('botright vsplit ' .. file_path)
+
+  local split_orientation = 'vsplit'
+  if config.split_orientation == 'horizontal' then
+      split_orientation = 'split'
+  end
+  vim.api.nvim_command('botright ' .. split_orientation .. ' ' .. file_path)
 
   local buf = vim.api.nvim_get_current_buf()
 

--- a/lua/luapad/config.lua
+++ b/lua/luapad/config.lua
@@ -32,10 +32,12 @@ local Config = {
   print_highlight = 'Comment',
   error_highlight = 'ErrorMsg',
   eval_on_move = false,
-  eval_on_change = true
+  eval_on_change = true,
+  split_orientation = 'vertical'
 }
 
 local function set_config(opts)
+  opts = opts or {}
   for k, v in pairs(opts) do Config[k] = v end
 end
 


### PR DESCRIPTION
Add an option so that when `Luapad` opens a new split in the orientation
configured for the plugin (i.e. 'vertical', 'horizonal').