### PR TITLE
feat: Implement buffer profiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,16 @@ require('galaxyline').section.right[1] = {
 </details>
 <br>
 
+### Profiler
+
+Luapad can profile the contents of the buffers. Add the following line to your buffer as a comment:
+
+```lua
+-- PROFILE 
+
+-- or to specify the number of times the buffer should be run: (defaults to 10)
+-- PROFILE 1000
+```
 
 ### Types of errors
 

--- a/lua/luapad/benchmark.lua
+++ b/lua/luapad/benchmark.lua
@@ -1,0 +1,53 @@
+local Config = require("luapad.config").config
+local hrtime = vim.loop.hrtime
+
+local Benchmark = {}
+Benchmark.__index = Benchmark
+Benchmark.benchmark_index = 1
+
+function Benchmark:start_benchmark(f, iterations, handle_result)
+	self.benchmark_index = self.benchmark_index + 1
+	local this_benchmark_index = self.benchmark_index
+	local total_time = 0
+	local cur_iteration = 0
+
+	local run_iter
+	run_iter = function()
+		cur_iteration = cur_iteration + 1
+		vim.defer_fn(function()
+			if self.benchmark_index == this_benchmark_index then
+				local start = hrtime()
+				self:tcall(f)
+				local stop = hrtime()
+				local diff = (stop - start) / 1e6
+				total_time = total_time + diff
+				if cur_iteration <= iterations then
+					self:update_view(total_time, cur_iteration, iterations, handle_result)
+					run_iter()
+				end
+			end
+		end, 5)
+	end
+
+	run_iter()
+end
+
+function Benchmark:update_view(total_time, cur_iteration, max_iterations, handle_result)
+	local percentage = ("%s"):format(math.floor((cur_iteration / max_iterations) * 100))
+	local percentage_str = string.rep(" ", 3 - #percentage) .. percentage .. "%"
+	local avg_time = total_time / cur_iteration
+	handle_result(("BENCHMARK: %s ms (avg, %s of %s iterations)"):format(avg_time, percentage_str, max_iterations))
+end
+
+function Benchmark:tcall(fun)
+	local count_limit = Config.count_limit < 1000 and 1000 or Config.count_limit
+	pcall(function()
+		debug.sethook(function()
+			error("LuapadTimeoutError")
+		end, "", count_limit)
+		fun()
+	end)
+	debug.sethook()
+end
+
+return Benchmark

--- a/lua/luapad/config.lua
+++ b/lua/luapad/config.lua
@@ -31,6 +31,7 @@ local Config = {
   count_limit = 2 * 1e5,
   print_highlight = 'Comment',
   error_highlight = 'ErrorMsg',
+  benchmark_highlight = "IncSearch",
   eval_on_move = false,
   eval_on_change = true,
   split_orientation = 'vertical'

--- a/lua/luapad/tools.lua
+++ b/lua/luapad/tools.lua
@@ -37,6 +37,15 @@ local function print_error(str)
   vim.api.nvim_command('echohl None')
 end
 
+local function table_find(tbl, predicate)
+  for i, v in ipairs(tbl) do
+    if predicate(v) then
+      return v, i
+    end
+  end
+  return nil
+end
+
 
 return {
   parse_error = parse_error,
@@ -45,5 +54,6 @@ return {
   create_file = create_file,
   remove_file = remove_file,
   print_warn = print_warn,
-  print_error = print_error
+  print_error = print_error,
+  table_find = table_find
 }


### PR DESCRIPTION
<img width="395" alt="Screen Shot 2022-11-11 at 7 03 30 pm" src="https://user-images.githubusercontent.com/7402063/201294075-a1f95e1d-9e7f-4882-8291-0e1ef22d4237.png">

Adds a profiler to Luapad by adding the comment
```lua
-- PROFILE [iteration_count]
```

Just a draft PR because I would like some feedback.  Any thoughts on how I can asyncronously update the virtual text?  I'm thinking it shows the profiling percentage and the current average time i.e.
`..1% -- 0.43354353ms avg (1 iteration)`
`.50% -- 0.43354353ms avg (5 iterations)`
`100% -- 0.43354353ms avg (10 iterations)`

Also is this a suitable implementation for adding profiling in general?  Should the check for `-- PROFILE` be a bit more structured i.e. something like `-- #luapad:profile [var1] [var2] [var3] ..`. 

Edit: "Benchmark" is probably a better term for this. *Updated to use `#luapad:benchmark [iter_count]`*